### PR TITLE
Fix the web functionality smoke test

### DIFF
--- a/packages/web-functionality/src/smoke.test.ts
+++ b/packages/web-functionality/src/smoke.test.ts
@@ -1,27 +1,22 @@
-describe('Smoke tests', () => {
-    beforeEach(async () => {
-        await page.goto(process.env.SOURCEGRAPH_URL || '')
-    })
+const searchUrl = process.env.SOURCEGRAPH_URL || ''
+const resultCountSelector = '[data-testid="streaming-progress-skipped"]'
+const searchQuery = 'repo:^github.com/sourcegraph/smoke-tests-test-repository$'
+const expectedResultString = '1 result'
 
+describe('Smoke tests', () => {
     it('successfully loads the application', async () => {
+        await page.goto(searchUrl)
         await expect(page).toMatch('Sourcegraph')
     })
 
     it('successful runs a search', async () => {
-        // Update search input
-        await page.waitForSelector('.test-query-input textarea')
-        await expect(page).toFill(
-            '.test-query-input textarea',
-            'repo:^github.com/sourcegraph/smoke-tests-test-repository$'
-        )
-
-        // Click search button
-        await expect(page).toClick('.test-search-button')
+        // Perform a search by navigating to a search results page with the q parameter
+        await page.goto(searchUrl + `?q=${encodeURIComponent(searchQuery)}`)
 
         // Expect results count is shown correctly
-        await page.waitForSelector('[data-testid="streaming-progress-count"]')
-        await expect(page).toMatchElement('[data-testid="streaming-progress-count"]', {
-            text: '1 result',
+        await page.waitForSelector(resultCountSelector)
+        await expect(page).toMatchElement(resultCountSelector, {
+            text: expectedResultString,
         })
     })
 })


### PR DESCRIPTION
Fix the smoke tests that were broken because we changed the implementation of the search query input.

The test now navigates to the search results page using the `q` parameter to perform a test and (like before) it checks the count of 1 result for the search of the named repo.