### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
       # set up correct version of node
       - id: nvmrc
-        run: echo ::set-output name=NODE_VERSION::$(cat ../../.nvmrc)
+        run: echo NODE_VERSION=$(cat ../../.nvmrc) >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v2
         with: { node-version: '${{ steps.nvmrc.outputs.NODE_VERSION }}' }
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -13,7 +13,7 @@ jobs:
 
       # set up correct version of node
       - id: nvmrc
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        run: echo NODE_VERSION=$(cat .nvmrc) >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v2
         with: { node-version: '${{ steps.nvmrc.outputs.NODE_VERSION }}' }
 


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter